### PR TITLE
[Add] add support for docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,8 @@ FROM ros:noetic-perception
 
 RUN apt-get update && apt-get install -y \
     ros-noetic-rviz \
+    # To enable VS Code debugging outside the container
+    gdb \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/catkin_ws/src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM ros:noetic-perception
+
+RUN apt-get update && apt-get install -y \
+    ros-noetic-rviz \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root/catkin_ws/src
+
+COPY . ./FAST-Calib
+
+WORKDIR /root/catkin_ws
+
+RUN /bin/bash -c "source /opt/ros/noetic/setup.bash && catkin_make"
+
+RUN echo "source /root/catkin_ws/devel/setup.bash" >> ~/.bashrc

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -1,0 +1,6 @@
+WORK_WS=/root/catkin_ws/src/FAST-Calib
+DOCKERIMAGE="fast_calib:latest"
+xhost +
+CURRENT_DIR=$(pwd)
+docker run -it --rm --runtime=nvidia --gpus all  --net=host -v ${CURRENT_DIR}:${WORK_WS} \
+    -v /dev/:/dev/ --privileged -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix  --name="fast_calib" ${DOCKERIMAGE} /bin/bash 


### PR DESCRIPTION
**Description**:

Hi, I have added two files to provide Docker support for this project.

-  `docker/Dockerfile`: Used to build the Docker image, containing all necessary dependencies.

- `start_docker.sh`: A helper script to launch the container with GUI support (X11 forwarding), allowing display output (like RViz, Gazebo, or OpenCV windows) to work outside the container.